### PR TITLE
Test fix and some renaming

### DIFF
--- a/src/postgres/src/backend/libpq/auth.c
+++ b/src/postgres/src/backend/libpq/auth.c
@@ -658,7 +658,7 @@ ClientAuthentication(Port *port)
 		{
 			Oid roleid = HeapTupleGetOid(roleTup);
 			ReleaseSysCache(roleTup);
-			ResetProfileFailedAttempts(roleid);
+			YBCResetFailedAttemptsIfAllowed(roleid);
 		}
 		else
 		{
@@ -673,7 +673,7 @@ ClientAuthentication(Port *port)
 		{
 			Oid roleid = HeapTupleGetOid(roleTup);
 			ReleaseSysCache(roleTup);
-			IncFailedAttemptsAndMaybeDisableProfile(roleid);
+			YBCIncFailedAttemptsAndMaybeDisableProfile(roleid);
 		}
 		else
 		{

--- a/src/postgres/src/include/commands/profile.h
+++ b/src/postgres/src/include/commands/profile.h
@@ -52,8 +52,9 @@ extern void RemoveProfileById(Oid prf_oid);
 
 extern Oid CreateRoleProfile(Oid rolid, const char* profile);
 extern Oid EnableRoleProfile(Oid roleid, bool isEnabled);
-extern void IncFailedAttemptsAndMaybeDisableProfile(Oid roleid);
-extern void ResetProfileFailedAttempts(Oid roleid);
+extern Oid IncFailedAttemptsAndMaybeDisableProfile(Oid roleid);
+extern void YBCIncFailedAttemptsAndMaybeDisableProfile(Oid roleid);
+extern void YBCResetFailedAttemptsIfAllowed(Oid roleid);
 
 extern Oid	 get_role_profile_oid(Oid rolid, bool missing_ok);
 extern HeapTuple get_role_profile_tuple(Oid rolid);

--- a/src/postgres/src/test/regress/sql/yb_role_inc_and_disable.sql
+++ b/src/postgres/src/test/regress/sql/yb_role_inc_and_disable.sql
@@ -1,43 +1,38 @@
 CREATE PROFILE ind_profile FAILED ATTEMPTS 2;
-CREATE USER ind_user PASSWORD 'pass';
+CREATE USER ind_user;
 
-SELECT prfname, prffailedloginattempts FROM pg_yb_profile ORDER BY OID;
-SELECT rolname from pg_roles WHERE rolname = 'ind_user';
+SELECT prfname, prffailedloginattempts FROM pg_catalog.pg_yb_profile ORDER BY OID;
+SELECT rolname from pg_catalog.pg_roles WHERE rolname = 'ind_user';
 
 ALTER USER ind_user PROFILE ATTACH ind_profile;
 
-SELECT rolisenabled, rolfailedloginattempts, rolname, prfname
-    FROM pg_yb_role_profile rp
-    JOIN pg_roles rol ON rp.rolid = rol.oid
-    JOIN pg_yb_profile lp ON rp.prfid = lp.oid;
+SELECT rolisenabled, rolfailedloginattempts, rolname, prfname FROM
+    pg_catalog.pg_yb_role_profile rp JOIN pg_catalog.pg_roles rol ON rp.rolid = rol.oid
+    JOIN pg_catalog.pg_yb_profile lp ON rp.prfid = lp.oid;
 
 -- A failed attempt increments the counter
 ALTER USER ind_user PROFILE ATTEMPTS FAILED;
-SELECT rolisenabled, rolfailedloginattempts, rolname, prfname
-    FROM pg_yb_role_profile rp
-    JOIN pg_roles rol ON rp.rolid = rol.oid
-    JOIN pg_yb_profile lp ON rp.prfid = lp.oid;
+SELECT rolisenabled, rolfailedloginattempts, rolname, prfname FROM
+    pg_catalog.pg_yb_role_profile rp JOIN pg_catalog.pg_roles rol ON rp.rolid = rol.oid
+    JOIN pg_catalog.pg_yb_profile lp ON rp.prfid = lp.oid;
 
  -- One more is allowed
 ALTER USER ind_user PROFILE ATTEMPTS FAILED;
-SELECT rolisenabled, rolfailedloginattempts, rolname, prfname
-    FROM pg_yb_role_profile rp
-    JOIN pg_roles rol ON rp.rolid = rol.oid
-    JOIN pg_yb_profile lp ON rp.prfid = lp.oid;
+SELECT rolisenabled, rolfailedloginattempts, rolname, prfname FROM
+    pg_catalog.pg_yb_role_profile rp JOIN pg_catalog.pg_roles rol ON rp.rolid = rol.oid
+    JOIN pg_catalog.pg_yb_profile lp ON rp.prfid = lp.oid;
 
  -- Increment and disable
 ALTER USER ind_user PROFILE ATTEMPTS FAILED;
-SELECT rolisenabled, rolfailedloginattempts, rolname, prfname
-    FROM pg_yb_role_profile rp
-    JOIN pg_roles rol ON rp.rolid = rol.oid
-    JOIN pg_yb_profile lp ON rp.prfid = lp.oid;
+SELECT rolisenabled, rolfailedloginattempts, rolname, prfname FROM
+    pg_catalog.pg_yb_role_profile rp JOIN pg_catalog.pg_roles rol ON rp.rolid = rol.oid
+    JOIN pg_catalog.pg_yb_profile lp ON rp.prfid = lp.oid;
 
 --Enable should reset the counter
 ALTER USER ind_user PROFILE ENABLE;
-SELECT rolisenabled, rolfailedloginattempts, rolname, prfname
-    FROM pg_yb_role_profile rp
-    JOIN pg_roles rol ON rp.rolid = rol.oid
-    JOIN pg_yb_profile lp ON rp.prfid = lp.oid;
+SELECT rolisenabled, rolfailedloginattempts, rolname, prfname FROM
+    pg_catalog.pg_yb_role_profile rp JOIN pg_catalog.pg_roles rol ON rp.rolid = rol.oid
+    JOIN pg_catalog.pg_yb_profile lp ON rp.prfid = lp.oid;
 
 DROP USER ind_user;
 DROP PROFILE ind_profile;


### PR DESCRIPTION
- Added a YBC prefix to the profile.c functions that use YBCExec... to make it clear that they directly write. 
- Reintroduced the old IncAndMaybeDisable function that just uses regular catalog writes. We can use this for the ALTER USER commands, rather than using a shortcut. If we decide that we don't need the ALTER USER backdoor, we can drop this function. 