### PR TITLE
Profile Login Java test

### DIFF
--- a/java/yb-pgsql/src/test/java/org/yb/pgsql/BasePgSQLTest.java
+++ b/java/yb-pgsql/src/test/java/org/yb/pgsql/BasePgSQLTest.java
@@ -23,8 +23,6 @@ import static org.yb.AssertionWrappers.fail;
 import static org.yb.util.BuildTypeUtil.isASAN;
 import static org.yb.util.BuildTypeUtil.isTSAN;
 
-import java.io.ByteArrayOutputStream;
-import java.io.PrintStream;
 import java.io.File;
 import java.net.InetSocketAddress;
 import java.net.URL;
@@ -73,9 +71,11 @@ import org.yb.minicluster.MiniYBClusterBuilder;
 import org.yb.minicluster.MiniYBDaemon;
 import org.yb.minicluster.RocksDBMetrics;
 import org.yb.minicluster.YsqlSnapshotVersion;
-import org.yb.util.*;
-import org.yb.util.ThrowingRunnable;
+import org.yb.util.BuildTypeUtil;
+import org.yb.util.EnvAndSysPropertyUtil;
 import org.yb.util.MiscUtil.ThrowingCallable;
+import org.yb.util.SystemUtil;
+import org.yb.util.ThrowingRunnable;
 import org.yb.util.YBBackupException;
 import org.yb.util.YBBackupUtil;
 
@@ -109,6 +109,7 @@ public class BasePgSQLTest extends BaseMiniClusterTest {
   protected static final String DEFAULT_PG_USER = "yugabyte";
   protected static final String DEFAULT_PG_PASS = "yugabyte";
   protected static final String TEST_PG_USER = "yugabyte_test";
+  protected static final String TEST_PG_PASS = "pass";
 
   // Non-standard PSQL states defined in yb_pg_errcodes.h
   protected static final String SERIALIZATION_FAILURE_PSQL_STATE = "40001";
@@ -322,13 +323,13 @@ public class BasePgSQLTest extends BaseMiniClusterTest {
     }
 
     // Create test role.
-    try (Connection initialConnection = getConnectionBuilder().withUser(DEFAULT_PG_USER).connect();
+    try (Connection initialConnection = getConnectionBuilder().withUser(DEFAULT_PG_USER).withPassword(DEFAULT_PG_PASS).connect();
          Statement statement = initialConnection.createStatement()) {
       statement.execute(
-          "CREATE ROLE " + TEST_PG_USER + " SUPERUSER CREATEROLE CREATEDB BYPASSRLS LOGIN");
+          "CREATE ROLE " + TEST_PG_USER + " SUPERUSER CREATEROLE CREATEDB BYPASSRLS LOGIN PASSWORD '" + TEST_PG_PASS + "'");
     }
 
-    connection = getConnectionBuilder().connect();
+    connection = getConnectionBuilder().withPassword(TEST_PG_PASS).connect();
     pgInitialized = true;
   }
 

--- a/java/yb-pgsql/src/test/java/org/yb/pgsql/TestYbRoleProfile.java
+++ b/java/yb-pgsql/src/test/java/org/yb/pgsql/TestYbRoleProfile.java
@@ -1,0 +1,184 @@
+// Copyright (c) YugaByte, Inc.
+//
+// Licensed under the Apache License, Version 2.0 (the "License"); you may not use this file except
+// in compliance with the License.  You may obtain a copy of the License at
+//
+// http://www.apache.org/licenses/LICENSE-2.0
+//
+// Unless required by applicable law or agreed to in writing, software distributed under the License
+// is distributed on an "AS IS" BASIS, WITHOUT WARRANTIES OR CONDITIONS OF ANY KIND, either express
+// or implied.  See the License for the specific language governing permissions and limitations
+// under the License.
+//
+
+package org.yb.pgsql;
+
+import static org.junit.Assert.assertEquals;
+import static org.yb.AssertionWrappers.assertFalse;
+
+import java.sql.Connection;
+import java.sql.ResultSet;
+import java.sql.Statement;
+import java.util.Map;
+
+import org.junit.After;
+import org.junit.Before;
+import org.junit.Test;
+import org.junit.runner.RunWith;
+import org.slf4j.Logger;
+import org.slf4j.LoggerFactory;
+import org.yb.YBTestRunner;
+
+import com.yugabyte.util.PSQLException;
+
+@RunWith(value=YBTestRunner.class)
+public class TestYbRoleProfile extends BasePgSQLTest {
+
+  private static final Logger LOG = LoggerFactory.getLogger(TestPgSequences.class);
+  private static final String PROFILE_USERNAME = "profile_user";
+  private static final String PROFILE_USER_PASS = "profile_password";
+  private static final String PROFILE_NAME = "prf";
+  private static final String AUTHENTICATION_FAILED_MESSAGE = String.format("FATAL: password authentication failed for user \"%s\"", PROFILE_USERNAME);;
+  private static final String CANNOT_LOGIN_MESSAGE = String.format("FATAL: role \"%s\" is not permitted to log in", PROFILE_USERNAME);
+  private static final int FAILED_ATTEMPTS = 3;
+
+  @Override
+  protected Map<String, String> getTServerFlags() {
+    Map<String, String> flagMap = super.getTServerFlags();
+    flagMap.put("ysql_enable_auth", "true");
+    return flagMap;
+  }
+
+  private void attemptLogin(String username, String password, String expectedError) throws Exception {
+    try {
+      getConnectionBuilder()
+        .withTServer(0)
+        .withUser(username)
+        .withPassword(password)
+        .connect();
+    } catch (PSQLException e) {
+      if (expectedError == null)
+        throw e;
+
+      assertEquals(expectedError, e.getMessage());
+    }
+  }
+
+  private void login(String username, String password) throws Exception {
+    Connection connection = getConnectionBuilder()
+      .withTServer(0)
+      .withUser(username)
+      .withPassword(password)
+      .connect();
+
+    connection.close();
+  }
+
+  private void assertProfileStateForUser(String username, int expectedFailedLogins, boolean expectedEnabled) throws Exception {
+    try (Statement stmt = connection.createStatement()) {
+      ResultSet result = stmt.executeQuery(String.format("SELECT rolisenabled, rolfailedloginattempts " +
+                                                         "FROM pg_yb_role_profile rp " +
+                                                         "JOIN pg_roles rol ON rp.rolid = rol.oid " +
+                                                         "WHERE rol.rolname = '%s'",
+                                                         username));
+      while (result.next()) {
+        assertEquals(expectedFailedLogins, Integer.parseInt(result.getString("rolfailedloginattempts")));
+        assertEquals(expectedEnabled, result.getString("rolisenabled").equals("t"));
+        assertFalse(result.next());
+      }
+    }
+  }
+
+  private void unlockUser(String username) throws Exception {
+    try (Statement stmt = connection.createStatement()) {
+      stmt.execute(String.format("ALTER USER %s PROFILE ENABLE", PROFILE_USERNAME));
+    }
+  }
+
+  private void lockUser(String username) throws Exception {
+    try (Statement stmt = connection.createStatement()) {
+      stmt.execute(String.format("ALTER USER %s PROFILE DISABLE", PROFILE_USERNAME));
+    }
+  }
+
+  @After
+  public void cleanup() throws Exception {
+    try (Statement stmt = connection.createStatement()) {
+      stmt.execute(String.format("DROP USER %s", PROFILE_USERNAME));
+      stmt.execute(String.format("DROP PROFILE %s", PROFILE_NAME));
+    }
+  }
+
+  @Before
+  public void setup() throws Exception {
+    try (Statement stmt = connection.createStatement()) {
+      stmt.execute(String.format("CREATE USER %s PASSWORD '%s'", PROFILE_USERNAME, PROFILE_USER_PASS));
+      stmt.execute(String.format("CREATE PROFILE %s FAILED ATTEMPTS %d", PROFILE_NAME, FAILED_ATTEMPTS));
+      stmt.execute(String.format("ALTER USER %s PROFILE ATTACH %s", PROFILE_USERNAME, PROFILE_NAME));
+    }
+  }
+
+  @Test
+  public void testAdminCanUnlock() throws Exception {
+    /* Exceed the failed attempts limit */
+    for (int i = 0; i < FAILED_ATTEMPTS + 1; i++) {
+      attemptLogin(PROFILE_USERNAME, "wrong", AUTHENTICATION_FAILED_MESSAGE);
+    }
+    assertProfileStateForUser(PROFILE_USERNAME, FAILED_ATTEMPTS + 1, false);
+
+    /* Now the user cannot login */
+    attemptLogin(PROFILE_USERNAME, PROFILE_USER_PASS, CANNOT_LOGIN_MESSAGE);
+
+    /* After an admin resets, the user can login again */
+    unlockUser(PROFILE_USERNAME);
+    assertProfileStateForUser(PROFILE_USERNAME, 0, true);
+    login(PROFILE_USERNAME, PROFILE_USER_PASS);
+  }
+
+  @Test
+  public void testAdminCanLockAndUnlock() throws Exception {
+    /* Exceed the failed attempts limit */
+    lockUser(PROFILE_USERNAME);
+    assertProfileStateForUser(PROFILE_USERNAME, 0, false);
+
+    /* Now the user cannot login */
+    attemptLogin(PROFILE_USERNAME, PROFILE_USER_PASS, CANNOT_LOGIN_MESSAGE);
+
+    /* After an admin resets, the user can login again */
+    unlockUser(PROFILE_USERNAME);
+    assertProfileStateForUser(PROFILE_USERNAME, 0, true);
+    login(PROFILE_USERNAME, PROFILE_USER_PASS);
+  }
+
+  @Test
+  public void testLogin() throws Exception {
+    assertProfileStateForUser(PROFILE_USERNAME, 0, true);
+
+    login(PROFILE_USERNAME, PROFILE_USER_PASS);
+    assertProfileStateForUser(PROFILE_USERNAME, 0, true);
+
+    /* Use up all allowed failed attempts */
+    for (int i = 0; i < FAILED_ATTEMPTS; i++) {
+      attemptLogin(PROFILE_USERNAME, "wrong", AUTHENTICATION_FAILED_MESSAGE);
+      assertProfileStateForUser(PROFILE_USERNAME, i + 1, true);
+    }
+
+    /* A successful login wipes the slate clean */
+    login(PROFILE_USERNAME, PROFILE_USER_PASS);
+    assertProfileStateForUser(PROFILE_USERNAME, 0, true);
+
+    /* Now exceed the failed attempts limit */
+    for (int i = 0; i < FAILED_ATTEMPTS + 1; i++) {
+      assertProfileStateForUser(PROFILE_USERNAME, i, true);
+      attemptLogin(PROFILE_USERNAME, "wrong", AUTHENTICATION_FAILED_MESSAGE);
+    }
+    assertProfileStateForUser(PROFILE_USERNAME, FAILED_ATTEMPTS + 1, false);
+
+    /* A correct password gives a different error message and does not increment the failed counts*/
+    attemptLogin(PROFILE_USERNAME, PROFILE_USER_PASS, CANNOT_LOGIN_MESSAGE);
+    assertProfileStateForUser(PROFILE_USERNAME, FAILED_ATTEMPTS + 1, false);
+
+    attemptLogin(PROFILE_USERNAME, "wrong", AUTHENTICATION_FAILED_MESSAGE);
+    assertProfileStateForUser(PROFILE_USERNAME, FAILED_ATTEMPTS + 2, false);
+  }
+}

--- a/java/yb-pgsql/src/test/java/org/yb/pgsql/TestYbRoleProfile.java
+++ b/java/yb-pgsql/src/test/java/org/yb/pgsql/TestYbRoleProfile.java
@@ -39,7 +39,6 @@ public class TestYbRoleProfile extends BasePgSQLTest {
   private static final String PROFILE_USER_PASS = "profile_password";
   private static final String PROFILE_NAME = "prf";
   private static final String AUTHENTICATION_FAILED_MESSAGE = String.format("FATAL: password authentication failed for user \"%s\"", PROFILE_USERNAME);;
-  private static final String CANNOT_LOGIN_MESSAGE = String.format("FATAL: role \"%s\" is not permitted to log in", PROFILE_USERNAME);
   private static final int FAILED_ATTEMPTS = 3;
 
   @Override
@@ -127,7 +126,7 @@ public class TestYbRoleProfile extends BasePgSQLTest {
     assertProfileStateForUser(PROFILE_USERNAME, FAILED_ATTEMPTS + 1, false);
 
     /* Now the user cannot login */
-    attemptLogin(PROFILE_USERNAME, PROFILE_USER_PASS, CANNOT_LOGIN_MESSAGE);
+    attemptLogin(PROFILE_USERNAME, PROFILE_USER_PASS, AUTHENTICATION_FAILED_MESSAGE);
 
     /* After an admin resets, the user can login again */
     unlockUser(PROFILE_USERNAME);
@@ -142,7 +141,7 @@ public class TestYbRoleProfile extends BasePgSQLTest {
     assertProfileStateForUser(PROFILE_USERNAME, 0, false);
 
     /* Now the user cannot login */
-    attemptLogin(PROFILE_USERNAME, PROFILE_USER_PASS, CANNOT_LOGIN_MESSAGE);
+    attemptLogin(PROFILE_USERNAME, PROFILE_USER_PASS, AUTHENTICATION_FAILED_MESSAGE);
 
     /* After an admin resets, the user can login again */
     unlockUser(PROFILE_USERNAME);
@@ -175,10 +174,10 @@ public class TestYbRoleProfile extends BasePgSQLTest {
     assertProfileStateForUser(PROFILE_USERNAME, FAILED_ATTEMPTS + 1, false);
 
     /* A correct password gives a different error message and does not increment the failed counts*/
-    attemptLogin(PROFILE_USERNAME, PROFILE_USER_PASS, CANNOT_LOGIN_MESSAGE);
-    assertProfileStateForUser(PROFILE_USERNAME, FAILED_ATTEMPTS + 1, false);
+    attemptLogin(PROFILE_USERNAME, PROFILE_USER_PASS, AUTHENTICATION_FAILED_MESSAGE);
+    assertProfileStateForUser(PROFILE_USERNAME, FAILED_ATTEMPTS + 2, false);
 
     attemptLogin(PROFILE_USERNAME, "wrong", AUTHENTICATION_FAILED_MESSAGE);
-    assertProfileStateForUser(PROFILE_USERNAME, FAILED_ATTEMPTS + 2, false);
+    assertProfileStateForUser(PROFILE_USERNAME, FAILED_ATTEMPTS + 3, false);
   }
 }

--- a/src/postgres/src/backend/libpq/auth.c
+++ b/src/postgres/src/backend/libpq/auth.c
@@ -360,22 +360,6 @@ auth_failed(Port *port, int status, char *logdetail)
 	/* doesn't return */
 }
 
-
-static int
-track_login_attempts(Port* port, int status)
-{
-	HeapTuple roleTup;
-	/* Get role info from pg_authid */
-	roleTup = SearchSysCache1(AUTHNAME, PointerGetDatum(port->user_name));
-	if (HeapTupleIsValid(roleTup))
-	{
-		Oid roleid = HeapTupleGetOid(roleTup);
-		elog(LOG, "Place holder to track login attempt for %d", roleid);
-		ReleaseSysCache(roleTup);
-	}
-	return status;
-}
-
 /*
  * Client authentication starts here.  If there is an error, this
  * function does not return and the backend process is terminated.
@@ -591,11 +575,11 @@ ClientAuthentication(Port *port)
 
 		case uaMD5:
 		case uaSCRAM:
-			status = track_login_attempts(port, CheckPWChallengeAuth(port, &logdetail));
+			status = CheckPWChallengeAuth(port, &logdetail);
 			break;
 
 		case uaPassword:
-			status = track_login_attempts(port, CheckPasswordAuth(port, &logdetail));
+			status = CheckPasswordAuth(port, &logdetail);
 			break;
 
 		case uaYbTserverKey:
@@ -668,7 +652,6 @@ ClientAuthentication(Port *port)
 	}
 	else
 	{
-		// Oid database_oid = 1; // get_database_oid(port->database_name, false);
 		if (HeapTupleIsValid(roleTup))
 		{
 			Oid roleid = HeapTupleGetOid(roleTup);

--- a/src/postgres/src/backend/utils/init/miscinit.c
+++ b/src/postgres/src/backend/utils/init/miscinit.c
@@ -655,22 +655,6 @@ InitializeSessionUserId(const char *rolename, Oid roleid)
 					 errmsg("role \"%s\" is not permitted to log in",
 							rname)));
 
-		if (IsYugaByteEnabled())
-		{
-			HeapTuple rolprftuple = get_role_profile_tuple(MyProc->roleId);
-			if (HeapTupleIsValid(rolprftuple))
-			{
-				Form_pg_yb_role_profile rolprfform = (Form_pg_yb_role_profile)
-									GETSTRUCT(rolprftuple);
-
-				if (!rolprfform->rolisenabled)
-					ereport(FATAL,
-							(errcode(ERRCODE_INVALID_AUTHORIZATION_SPECIFICATION),
-							 errmsg("role \"%s\" is not permitted to log in",
-									rname)));
-			}
-		}
-
 		/*
 		 * Check connection limit for this role.
 		 *

--- a/src/postgres/src/test/regress/expected/yb_role_profile_disabled.out
+++ b/src/postgres/src/test/regress/expected/yb_role_profile_disabled.out
@@ -24,4 +24,4 @@ SELECT rolisenabled, rolfailedloginattempts, rolname, prfname FROM
 
 -- fail to connect if disabled
 \c yugabyte disabled_user
-\connect: FATAL:  role "disabled_user" is not permitted to log in
+\connect: FATAL:  "trust" authentication failed for user "disabled_user"


### PR DESCRIPTION
There are two commits as part of this PR: the first creates the tests and verifies the logic as is. 

The second commit changes some logic and updates the test. The profile validation logic was split between miscinit.c and auth.c, and each had a different behaviour. This meant that if the user was locked out but got the correct password, they would receive a different error message and the failed login attempts counter would not be incremented. So while they would be locked out, they could continue guessing the password because we revealed information to them. 