### PR TITLE
Fix new table issues, some YsqlUpgrade problems

### DIFF
--- a/java/yb-pgsql/src/test/java/org/yb/pgsql/TestYsqlUpgrade.java
+++ b/java/yb-pgsql/src/test/java/org/yb/pgsql/TestYsqlUpgrade.java
@@ -1659,7 +1659,6 @@ public class TestYsqlUpgrade extends BasePgSQLTest {
                                   pgTypeNameByOidMap.get(r.getLong(2)));
                             case "pg_opclass":
                             case "pg_opfamily":
-                            case "pg_yb_profile":
                               return r.getString(2);
                             default:
                               return r.getString(1);

--- a/src/postgres/src/backend/commands/ybccmds.c
+++ b/src/postgres/src/backend/commands/ybccmds.c
@@ -1261,7 +1261,7 @@ YBCPrepareAlterTableCmd(AlterTableCmd* cmd, Relation rel, List *handles,
 					SearchSysCache1(RELOID, ObjectIdGetDatum(relationId));
 				if (!HeapTupleIsValid(reltup))
 					elog(ERROR,
-						 "Cache lookup failed for relation %u",
+						 "cache lookup failed for relation %u",
 						  relationId);
 				Form_pg_class relform = (Form_pg_class) GETSTRUCT(reltup);
 				ReleaseSysCache(reltup);

--- a/src/postgres/src/backend/utils/cache/relcache.c
+++ b/src/postgres/src/backend/utils/cache/relcache.c
@@ -1940,8 +1940,12 @@ YBPreloadRelCache()
 	YbRegisterSysTableForPrefetching(TypeRelationId);                  // pg_type
 	YbRegisterSysTableForPrefetching(NamespaceRelationId);             // pg_namespace
 	YbRegisterSysTableForPrefetching(AuthIdRelationId);                // pg_authid
-	YbRegisterSysTableForPrefetching(YbProfileRelationId);             // yb_pg_profile
-	YbRegisterSysTableForPrefetching(YbRoleProfileRelationId);         // yb_pg_role_profile
+
+	if (YbLoginProfileCatalogsExist)
+	{
+		YbRegisterSysTableForPrefetching(YbProfileRelationId);         // yb_pg_profile
+		YbRegisterSysTableForPrefetching(YbRoleProfileRelationId);     // yb_pg_role_profile
+	}
 
 	if (!YBIsDBConnectionValid())
 		ereport(FATAL,
@@ -4128,8 +4132,8 @@ RelationBuildLocalRelation(const char *relname,
 	 * to the set of shared relations.
 	 */
 	if (shared_relation != IsSharedRelation(relid) && !yb_test_system_catalogs_creation)
-		elog(ERROR, "shared_relation flag for \"%s\" does not match IsSharedRelation(%u)",
-			 relname, relid);
+		elog(ERROR, "shared_relation flag for \"%s\" (%s) does not match IsSharedRelation(%u) (%s)",
+			 relname, shared_relation ? "true" : "false", relid, IsSharedRelation(relid) ? "true" : "false");
 
 	/* (Non-YB) shared relations had better be mapped, too */
 	Assert(IsYugaByteEnabled() ||
@@ -4514,12 +4518,15 @@ RelationCacheInitializePhase2(void)
 				  false, Natts_pg_shseclabel, Desc_pg_shseclabel);
 		formrdesc("pg_subscription", SubscriptionRelation_Rowtype_Id, true,
 				  true, Natts_pg_subscription, Desc_pg_subscription);
-		formrdesc("pg_yb_profile", YbProfileRelation_Rowtype_Id, true,
-				  true, Natts_pg_yb_profile, Desc_pg_yb_profile);
-		formrdesc("pg_yb_role_profile", YbRoleProfileRelation_Rowtype_Id, true,
-				  true, Natts_pg_yb_role_profile, Desc_pg_yb_role_profile);
+		if (YbLoginProfileCatalogsExist)
+		{
+			formrdesc("pg_yb_profile", YbProfileRelation_Rowtype_Id, true,
+					true, Natts_pg_yb_profile, Desc_pg_yb_profile);
+			formrdesc("pg_yb_role_profile", YbRoleProfileRelation_Rowtype_Id, true,
+					true, Natts_pg_yb_role_profile, Desc_pg_yb_role_profile);
+		}
 
-#define NUM_CRITICAL_SHARED_RELS	7	/* fix if you change list above */
+#define NUM_CRITICAL_SHARED_RELS    (YbLoginProfileCatalogsExist ? 7 : 5)   /* fix if you change list above */
 	}
 
 	MemoryContextSwitchTo(oldcxt);

--- a/src/postgres/src/backend/utils/init/globals.c
+++ b/src/postgres/src/backend/utils/init/globals.c
@@ -96,6 +96,8 @@ bool        MyColocatedDatabaseLegacy = true;
 
 bool		YbTablegroupCatalogExists = false;
 
+bool		YbLoginProfileCatalogsExist = false;
+
 /*
  * DatabasePath is the path (relative to DataDir) of my database's
  * primary directory, ie, its directory in the default tablespace.

--- a/src/postgres/src/backend/utils/init/postinit.c
+++ b/src/postgres/src/backend/utils/init/postinit.c
@@ -686,6 +686,10 @@ InitPostgresImpl(const char *in_dbname, Oid dboid, const char *username,
 
 	if (IsYugaByteEnabled() && !bootstrap)
 	{
+		HandleYBStatus(YBCPgTableExists(TemplateDbOid,
+										YbRoleProfileRelationId,
+										&YbLoginProfileCatalogsExist));
+
 		const uint64_t catalog_master_version =
 			YbGetCatalogCacheVersionForTablePrefetching();
 		YBCPgResetCatalogReadTime();
@@ -699,10 +703,14 @@ InitPostgresImpl(const char *in_dbname, Oid dboid, const char *username,
 				DbRoleSettingRelationId); // pg_db_role_setting
 		YbRegisterSysTableForPrefetching(
 				AuthMemRelationId);       // pg_auth_members
-		YbRegisterSysTableForPrefetching(
-				YbProfileRelationId);       // pg_yb_profile
-		YbRegisterSysTableForPrefetching(
-				YbRoleProfileRelationId);       // pg_yb_role_profile
+
+		if (YbLoginProfileCatalogsExist)
+		{
+			YbRegisterSysTableForPrefetching(
+					YbProfileRelationId); // pg_yb_profile
+			YbRegisterSysTableForPrefetching(
+					YbRoleProfileRelationId);	// pg_yb_role_profile
+		}
 		YbTryRegisterCatalogVersionTableForPrefetching();
 
 		/*

--- a/src/postgres/src/include/catalog/pg_yb_migration.dat
+++ b/src/postgres/src/include/catalog/pg_yb_migration.dat
@@ -12,7 +12,7 @@
 [
 
 # For better version control conflict detection, list latest migration filename
-# here: V29__14939__user_login_profiles.sql
+# here: V29__14939__yb_profiles.sql
 { major => '29', minor => '0', name => '<baseline>', time_applied => '_null_' }
 
 ]

--- a/src/postgres/src/include/miscadmin.h
+++ b/src/postgres/src/include/miscadmin.h
@@ -193,6 +193,8 @@ extern PGDLLIMPORT bool MyColocatedDatabaseLegacy;
 
 extern PGDLLIMPORT bool YbTablegroupCatalogExists;
 
+extern PGDLLIMPORT bool YbLoginProfileCatalogsExist;
+
 /*
  * Date/Time Configuration
  *

--- a/src/yb/yql/pgwrapper/ysql_migrations/V29__14939__yb_profiles.sql
+++ b/src/yb/yql/pgwrapper/ysql_migrations/V29__14939__yb_profiles.sql
@@ -2,14 +2,14 @@ BEGIN;
   CREATE TABLE IF NOT EXISTS pg_catalog.pg_yb_profile (
     prfname NAME NOT NULL,
     prffailedloginattempts SMALLINT NOT NULL,
-    prfpasswordlocktime INTEGER NOT NULL DEFAULT 0,
+    prfpasswordlocktime INTEGER NOT NULL,
     CONSTRAINT pg_yb_profile_oid_index PRIMARY KEY(oid ASC)
         WITH (table_oid = 8052)
   ) WITH (
     oids = true,
     table_oid = 8051,
     row_type_oid = 8053
-  );
+  ) TABLESPACE pg_global;
 COMMIT;
 
 BEGIN;
@@ -25,5 +25,5 @@ BEGIN;
     oids = true,
     table_oid = 8054,
     row_type_oid = 8056
-  );
+  ) TABLESPACE pg_global;
 COMMIT;


### PR DESCRIPTION
There are still some TestYsqlUpgrade test failures. 
* `creatingSystemRelsAfterFailure` fails on the master detective
* `upgradeIsIdempotentSingleConn` fails with the error `Could not reconnect to database`. This fails on my local master branch too. 
* `migratingIsEquivalentToReinitdb` fails with the error `TestYsqlUpgrade.migratingIsEquivalentToReinitdb:1034->assertMigrationsWorked:1690->lambda$50:1704->BasePgSQLTest.assertRow:1388 Table 'pg_attribute': Column #3 (atttypid) mismatch: expected:<int8> but was:<int4>`. This seems unrelated to profiles, so I'm not sure what's happening there. 

I also manually tested the table flags by:
```console
git checkout master
ybd reinitdb
git checkout -
ybd --sj 
./bin/yb-ctl restart 
./bin/ysqlsh
```
```sql
yugabyte=# CREATE PROFILE p FAILED ATTEMPTS 2;
ERROR:  Login profile system catalogs do not exist.
```
```console
ybd reinitdb
./bin/yb-ctl restart 
./bin/ysqlsh
```
```sql
yugabyte=# CREATE PROFILE p FAILED ATTEMPTS 2;
```