### PR TITLE
Profile Test Migrations, fix an YsqlUpgrade test

### DIFF
--- a/java/yb-pgsql/src/test/java/org/yb/pgsql/TestYsqlUpgrade.java
+++ b/java/yb-pgsql/src/test/java/org/yb/pgsql/TestYsqlUpgrade.java
@@ -1102,22 +1102,6 @@ public class TestYsqlUpgrade extends BasePgSQLTest {
     }
   }
 
-  @Test
-  public void testYbRoleProfile() throws Exception {
-    /*
-    * There are two operations that might result in an error if the profile catalogs don't exist:
-    *  1. logging in, because auth.c tries to get the user's profile if it exists
-    *  2. running profile commands.
-    * We can simply test this by logging in (which should behave as normal) and running a command.
-    */
-    recreateWithYsqlVersion(YsqlSnapshotVersion.EARLIEST);
-    try (Connection conn = getConnectionBuilder().withDatabase("template1").connect();
-         Statement stmt = conn.createStatement()) {
-          runInvalidQuery(stmt, "CREATE PROFILE p LIMIT FAILED_LOGIN_ATTEMPTS 3",
-                          "Login profile system catalogs do not exist");
-    }
-  }
-
   /** Invalid stuff which doesn't belong to other test cases. */
   @Test
   public void invalidUpgradeActions() throws Exception {

--- a/src/postgres/src/include/catalog/indexing.h
+++ b/src/postgres/src/include/catalog/indexing.h
@@ -371,7 +371,7 @@ DECLARE_UNIQUE_INDEX(pg_yb_catalog_version_db_oid_index, 8012, on pg_yb_catalog_
 DECLARE_UNIQUE_INDEX(pg_yb_profile_oid_index, 8052, on pg_yb_profile using btree(oid oid_ops));
 #define YbProfileOidIndexId 8052
 
-DECLARE_UNIQUE_INDEX(pg_yb_role_profile_oid_index, 8055, on pg_yb_role_profile using btree(rolid oid_ops));
+DECLARE_UNIQUE_INDEX(pg_yb_role_profile_oid_index, 8055, on pg_yb_role_profile using btree(oid oid_ops));
 #define YbRoleProfileOidIndexId 8055
 
 #endif							/* INDEXING_H */

--- a/src/postgres/src/include/catalog/pg_yb_role_profile.h
+++ b/src/postgres/src/include/catalog/pg_yb_role_profile.h
@@ -27,9 +27,9 @@
  */
 CATALOG(pg_yb_role_profile,8054,YbRoleProfileRelationId) BKI_SHARED_RELATION BKI_ROWTYPE_OID(8056,YbRoleProfileRelation_Rowtype_Id) BKI_SCHEMA_MACRO
 {
-	bool		rolisenabled;	/* Is the Role enabled? */
 	Oid			rolid;		/* OID of the role */
 	Oid			prfid;		/* OID of the profile */
+	bool		rolisenabled;	/* Is the Role enabled? */
 	int32		rolfailedloginattempts;  /* Number of failed attempts */
 	int64    	rollockedat;  /* Timestamp at which role was locked */
 } FormData_pg_yb_role_profile;

--- a/src/postgres/src/include/catalog/pg_yb_role_profile.h
+++ b/src/postgres/src/include/catalog/pg_yb_role_profile.h
@@ -31,7 +31,7 @@ CATALOG(pg_yb_role_profile,8054,YbRoleProfileRelationId) BKI_SHARED_RELATION BKI
 	Oid			prfid;		/* OID of the profile */
 	bool		rolisenabled;	/* Is the Role enabled? */
 	int32		rolfailedloginattempts;  /* Number of failed attempts */
-	int64    	rollockedat;  /* Timestamp at which role was locked */
+	int32    	rollockedat;  /* Timestamp at which role was locked */
 } FormData_pg_yb_role_profile;
 
 /* ----------------

--- a/src/yb/yql/pgwrapper/ysql_migrations/V29__14939__yb_profiles.sql
+++ b/src/yb/yql/pgwrapper/ysql_migrations/V29__14939__yb_profiles.sql
@@ -10,15 +10,13 @@ BEGIN;
     table_oid = 8051,
     row_type_oid = 8053
   ) TABLESPACE pg_global;
-COMMIT;
 
-BEGIN;
   CREATE TABLE IF NOT EXISTS pg_catalog.pg_yb_role_profile (
     rolid OID NOT NULL,
     prfid OID NOT NULL,
     rolisenabled BOOL NOT NULL,
     rolfailedloginattempts INTEGER NOT NULL,
-    rollockedat TIMESTAMPTZ NOT NULL,
+    rollockedat INTEGER NOT NULL,
     CONSTRAINT pg_yb_role_profile_oid_index PRIMARY KEY(oid ASC)
         WITH (table_oid = 8055)
   ) WITH (
@@ -26,4 +24,12 @@ BEGIN;
     table_oid = 8054,
     row_type_oid = 8056
   ) TABLESPACE pg_global;
+COMMIT;
+
+BEGIN;
+  SET LOCAL yb_non_ddl_txn_for_sys_tables_allowed TO true;
+
+  INSERT INTO pg_yb_profile (oid, prfname, prffailedloginattempts, prfpasswordlocktime)
+  VALUES (8057, 'default', 0, 0)
+  ON CONFLICT DO NOTHING;
 COMMIT;

--- a/src/yb/yql/pgwrapper/ysql_migrations/V29__14939__yb_profiles.sql
+++ b/src/yb/yql/pgwrapper/ysql_migrations/V29__14939__yb_profiles.sql
@@ -1,7 +1,7 @@
 BEGIN;
   CREATE TABLE IF NOT EXISTS pg_catalog.pg_yb_profile (
     prfname NAME NOT NULL,
-    prffailedloginattempts SMALLINT NOT NULL,
+    prffailedloginattempts INTEGER NOT NULL,
     prfpasswordlocktime INTEGER NOT NULL,
     CONSTRAINT pg_yb_profile_oid_index PRIMARY KEY(oid ASC)
         WITH (table_oid = 8052)
@@ -17,8 +17,8 @@ BEGIN;
     rolid OID NOT NULL,
     prfid OID NOT NULL,
     rolisenabled BOOL NOT NULL,
-    rolfailedloginattempts SMALLINT NOT NULL,
-    rollockts TIMESTAMPTZ NOT NULL,
+    rolfailedloginattempts INTEGER NOT NULL,
+    rollockedat TIMESTAMPTZ NOT NULL,
     CONSTRAINT pg_yb_role_profile_oid_index PRIMARY KEY(oid ASC)
         WITH (table_oid = 8055)
   ) WITH (


### PR DESCRIPTION
There are a few changes I made to the schema that are probably not exactly what we want. We can change them, as long as we change both `pg_yb_profile.h` and `V29__*.sql`. 

Tests:
```
ybd --java-test TestYsqlUpgrade#migratingIsEquivalentToReinitdb
ybd --java-test TestYbRoleProfile#testProfilesOnOldDbVersion
```