### PR TITLE
Fix Dependencies

### DIFF
--- a/src/postgres/src/backend/catalog/pg_shdepend.c
+++ b/src/postgres/src/backend/catalog/pg_shdepend.c
@@ -1154,8 +1154,6 @@ storeObjectDescription(StringInfo descs,
 				appendStringInfo(descs, _("target of %s"), objdesc);
 			else if (deptype == SHARED_DEPENDENCY_TABLESPACE)
 				appendStringInfo(descs, _("tablespace of %s"), objdesc);
-			else if (deptype == SHARED_DEPENDENCY_PROFILE)
-				appendStringInfo(descs, _("%s"), objdesc);
 			else
 				elog(ERROR, "unrecognized dependency type: %d",
 					 (int) deptype);
@@ -1341,12 +1339,6 @@ shdepDropOwned(List *roleids, DropBehavior behavior)
 						obj.objectSubId = sdepForm->objsubid;
 						add_exact_object_address(&obj, deleteobjs);
 					}
-					break;
-				case SHARED_DEPENDENCY_PROFILE:
-					/*
-					 * If it is a profile object, do not delete. Profile associations can be
-					 * removed by ALTER USER <u> NOLOGIN
-					 */
 					break;
 			}
 		}

--- a/src/postgres/src/backend/commands/user.c
+++ b/src/postgres/src/backend/commands/user.c
@@ -1117,6 +1117,9 @@ DropRole(DropRoleStmt *stmt)
 					(errcode(ERRCODE_INSUFFICIENT_PRIVILEGE),
 					 errmsg("must be superuser to drop superusers")));
 
+		if (*YBCGetGFlags()->ysql_enable_profile)
+			YbRemoveRoleProfileForRole(roleid, role);
+
 		/* DROP hook for the role being removed */
 		InvokeObjectDropHook(AuthIdRelationId, roleid, 0);
 

--- a/src/postgres/src/include/catalog/dependency.h
+++ b/src/postgres/src/include/catalog/dependency.h
@@ -81,6 +81,11 @@
  * created only during initdb.  The fields for the dependent object
  * contain zeroes.
  *
+ * DEPENDENCY_PROFILE ('f'): the dependent object is a profile and the
+ * referenced object is a user. Since we cannot drop users in a DROP ...
+ * CASCADE, dependencies of this type will yield an error indicating that the
+ * profile cannot be dropped while users are still attached to it.
+ *
  * Other dependency flavors may be needed in future.
  */
 
@@ -92,7 +97,8 @@ typedef enum DependencyType
 	DEPENDENCY_INTERNAL_AUTO = 'I',
 	DEPENDENCY_EXTENSION = 'e',
 	DEPENDENCY_AUTO_EXTENSION = 'x',
-	DEPENDENCY_PIN = 'p'
+	DEPENDENCY_PIN = 'p',
+	DEPENDENCY_PROFILE = 'f'
 } DependencyType;
 
 /*
@@ -129,10 +135,6 @@ typedef enum DependencyType
  * this: they are protected by the existence of a physical file in the
  * tablespace.)
  *
- * (f) a SHARED_DEPENDENCY_PROFILE entry means that the referenced object is
- * a role that is mentioned in a pg_yb_role_profile row.
- * The referenced object must be a pg_authid entry.
- *
  * SHARED_DEPENDENCY_INVALID is a value used as a parameter in internal
  * routines, and is not valid in the catalog itself.
  */
@@ -143,7 +145,6 @@ typedef enum SharedDependencyType
 	SHARED_DEPENDENCY_ACL = 'a',
 	SHARED_DEPENDENCY_POLICY = 'r',
 	SHARED_DEPENDENCY_TABLESPACE = 't',
-	SHARED_DEPENDENCY_PROFILE = 'f',
 	SHARED_DEPENDENCY_INVALID = 0
 } SharedDependencyType;
 

--- a/src/postgres/src/test/regress/expected/yb_role_profile.out
+++ b/src/postgres/src/test/regress/expected/yb_role_profile.out
@@ -34,6 +34,7 @@ SELECT oid, typname, typrelid FROM pg_type WHERE typname LIKE 'pg_yb_role_profil
 -- CREATE PROFILE
 --
 CREATE PROFILE test_profile LIMIT FAILED_LOGIN_ATTEMPTS 3;
+CREATE PROFILE test_profile_2 LIMIT FAILED_LOGIN_ATTEMPTS 3;
 CREATE USER restricted_user;
 -- fail: cannot lock/unlock a role that is not attached
 ALTER USER restricted_user ACCOUNT UNLOCK;
@@ -48,10 +49,11 @@ ALTER USER restricted_user PROFILE non_existent;
 ERROR:  profile "non_existent" does not exist
 -- Attach role to a profile
 SELECT prfname, prfmaxfailedloginattempts FROM pg_catalog.pg_yb_profile ORDER BY OID;
-   prfname    | prfmaxfailedloginattempts
---------------+---------------------------
- test_profile |                         3
-(1 row)
+    prfname     | prfmaxfailedloginattempts
+----------------+---------------------------
+ test_profile   |                         3
+ test_profile_2 |                         3
+(2 rows)
 
 SELECT rolname from pg_catalog.pg_roles WHERE rolname = 'restricted_user';
      rolname
@@ -61,8 +63,7 @@ SELECT rolname from pg_catalog.pg_roles WHERE rolname = 'restricted_user';
 
 ALTER USER restricted_user PROFILE test_profile;
 --
--- Ensure dependencies betwee pg_yb_role_profile & pg_yb_profile
--- and pg_yb_role_profile & pg_roles is setup correctly
+-- Ensure dependencies between role & pg_yb_profile is setup correctly
 -- There should be one row
 SELECT count(*) FROM pg_yb_role_profile;
  count
@@ -70,36 +71,11 @@ SELECT count(*) FROM pg_yb_role_profile;
      1
 (1 row)
 
--- One row in pg_shdepend for the role profile
-SELECT count(*) FROM pg_shdepend shdep
-                JOIN pg_yb_role_profile rpf on rpf.oid = shdep.objid
-                WHERE shdep.deptype = 'f';
- count
--------
-     1
-(1 row)
-
--- One row in pg_shdepend for the role
-SELECT count(*) FROM pg_shdepend shdep
-                JOIN pg_roles rol on rol.oid = shdep.refobjid
-                WHERE shdep.deptype = 'f' and rol.rolname = 'restricted_user';
- count
--------
-     1
-(1 row)
-
--- One row in pg_depend for the role profile
-SELECT count(*) FROM pg_depend dep
-                JOIN pg_yb_role_profile rpf on rpf.oid = dep.objid;
- count
--------
-     1
-(1 row)
-
--- One row in pg_depend for the profile
+-- One row in pg_depend for the profile -> role
 SELECT count(*) FROM pg_depend dep
                 JOIN pg_yb_profile prf on prf.oid = dep.refobjid
-                WHERE prf.prfname = 'test_profile';
+                JOIN pg_roles rol ON rol.oid = dep.objid
+                WHERE dep.deptype = 'f';
  count
 -------
      1
@@ -137,70 +113,40 @@ SELECT rolprfstatus, rolprffailedloginattempts, rolname, prfname FROM
 -- Associating a role to the same profile is a no-op
 ALTER USER restricted_user PROFILE test_profile;
 WARNING:  role "restricted_user" is already associated with profile "test_profile"
--- fail: Cannot drop a profile that has a role associated with it
+-- Associating a role to a different profile succeeds
+ALTER USER restricted_user PROFILE test_profile_2;
+-- We can drop a profile that does not have any users associated
 DROP PROFILE test_profile;
-ERROR:  cannot drop profile test_profile because other objects depend on it
-DETAIL:  association between role "restricted_user" and profile test_profile depends on profile test_profile
-HINT:  Use DROP ... CASCADE to drop the dependent objects too.
--- A role/user cannot be dropped because there is mapping to profile.
-DROP USER restricted_user;
-ERROR:  role "restricted_user" cannot be dropped because some objects depend on it
-DETAIL:  association between role "restricted_user" and profile test_profile
--- Remove the association of a role to a profile
+-- fail: Cannot drop a profile that has a role associated with it
+DROP PROFILE test_profile_2;
+ERROR:  cannot drop profile test_profile_2 because it is associated with role restricted_user
+HINT:  Use ALTER USER restricted_user NOPROFILE first.
+-- Removing the user's profile should clean up the mappings and dependencies.
 ALTER USER restricted_user NOPROFILE;
-SELECT rolprfstatus, rolprffailedloginattempts, rolname, prfname FROM
-    pg_catalog.pg_yb_role_profile rp JOIN pg_catalog.pg_roles rol ON rp.rolprfrole = rol.oid
-    JOIN pg_catalog.pg_yb_profile lp ON rp.rolprfprofile = lp.oid;
- rolprfstatus | rolprffailedloginattempts | rolname | prfname
---------------+---------------------------+---------+---------
-(0 rows)
-
---
--- Ensure dependencies betwee pg_yb_role_profile & pg_yb_profile
--- and pg_yb_role_profile & pg_roles is setup correctly
--- There should be zero rows
 SELECT count(*) FROM pg_yb_role_profile;
  count
 -------
      0
 (1 row)
 
--- pg_shdepend for the role profile
-SELECT count(*) FROM pg_shdepend shdep
-                JOIN pg_yb_role_profile rpf on rpf.oid = shdep.objid
-                WHERE shdep.deptype = 'f';
- count
--------
-     0
-(1 row)
-
--- pg_shdepend for the role
-SELECT count(*) FROM pg_shdepend shdep
-                JOIN pg_roles rol on rol.oid = shdep.refobjid
-                WHERE shdep.deptype = 'f' and rol.rolname = 'restricted_user';
- count
--------
-     0
-(1 row)
-
--- pg_depend for the role profile
-SELECT count(*) FROM pg_depend dep
-                JOIN pg_yb_role_profile rpf on rpf.oid = dep.objid;
- count
--------
-     0
-(1 row)
-
--- pg_depend for the profile
 SELECT count(*) FROM pg_depend dep
                 JOIN pg_yb_profile prf on prf.oid = dep.refobjid
-                WHERE prf.prfname = 'test_profile';
+                JOIN pg_roles rol ON rol.oid = dep.objid
+                WHERE dep.deptype = 'f';
  count
 -------
      0
 (1 row)
 
--- Can drop user as it is not attached to a profile. After dropping the user there should be 0 rows
+-- Setting a new profile creates a new row in pg_yb_role_profile
+ALTER USER restricted_user PROFILE test_profile_2;
+SELECT count(*) FROM pg_yb_role_profile;
+ count
+-------
+     1
+(1 row)
+
+-- Dropping the user should clean up the mappings and dependencies.
 DROP USER restricted_user;
 SELECT count(*) FROM pg_yb_role_profile;
  count
@@ -208,4 +154,13 @@ SELECT count(*) FROM pg_yb_role_profile;
      0
 (1 row)
 
-DROP PROFILE test_profile;
+SELECT count(*) FROM pg_depend dep
+                JOIN pg_yb_profile prf on prf.oid = dep.refobjid
+                JOIN pg_roles rol ON rol.oid = dep.objid
+                WHERE dep.deptype = 'f';
+ count
+-------
+     0
+(1 row)
+
+DROP PROFILE test_profile_2;


### PR DESCRIPTION
Updating the shared dependency in all situations ended up being a bit strange. 

When the deps were between role and pg_yb_role_profile, the only thing to change was when the role was entirely unassociated with a profile. 

But now that the role is dependent on a profile, cases where we change the profile would have required a lot of new custom logic, because there's nothing like that on pg_shdepend yet. (PG has a lot more functionality for pg_depend, which makes sense because there are many more uses for that table). 

I realized that it would be really simple to just drop the profile when dropping the user, so I did that instead. Now we don't need to track the profile dependencies from a user perspective, because we don't need to check them. 

```
yugabyte=# DROP PROFILE p;
ERROR:  cannot drop profile p because it is associated with role u
HINT:  Use ALTER USER u NOPROFILE first.
yugabyte=# DROP USER u;
DROP ROLE
yugabyte=# DROP PROFILE p;
DROP PROFILE
```