### PR TITLE
Fix yb backup

### DIFF
--- a/java/yb-pgsql/src/test/java/org/yb/pgsql/TestYbBackup.java
+++ b/java/yb-pgsql/src/test/java/org/yb/pgsql/TestYbBackup.java
@@ -1811,7 +1811,7 @@ public class TestYbBackup extends BasePgSQLTest {
       stmt.execute("INSERT INTO tbl SELECT generate_series(101,200)");
       assertQuery(stmt, "SELECT median(v) FROM tbl", new Row(100.5));
       // Test view.
-      assertQuery(stmt, "SELECT COUNT(*) FROM oracle.user_tables", new Row(76));
+      assertQuery(stmt, "SELECT COUNT(*) FROM oracle.user_tables", new Row(78));
 
       // Test whether extension membership is set correctly after restoration.
       stmt.execute("DROP EXTENSION orafce CASCADE");


### PR DESCRIPTION
Three problems:
1. the test asserts user_tables == 76
2. the test runs yb_backup.py
3. the test asserts user_tables == 76

I ran it locally and found problem 1, fixed it and found problem 2. I couldn't figure it out, but pushed my fix for problem 1. Then Jenkins errors with problem 3, not problem 2. So problem 2 seems to be a local problem, and this change should hopefully make it work on jenkins. 