### PR TITLE
WIP: check if user is locked out in postinit.c

### DIFF
--- a/src/postgres/src/backend/libpq/auth.c
+++ b/src/postgres/src/backend/libpq/auth.c
@@ -651,6 +651,7 @@ ClientAuthentication(Port *port)
 			{
 				Form_pg_yb_role_profile rolprfform = (Form_pg_yb_role_profile)
 											GETSTRUCT(profileTuple);
+				elog(WARNING, "role has %d failed attempts", rolprfform->rolprffailedloginattempts);
 				if (rolprfform->rolprfstatus != ROLPRFSTATUS_OPEN)
 				{
 					profile_is_disabled = true;
@@ -661,8 +662,6 @@ ClientAuthentication(Port *port)
 
 		if (status == STATUS_OK && !profile_is_disabled)
 		{
-			if (roleid != InvalidOid)
-				YbResetFailedAttemptsIfAllowed(roleid);
 			sendAuthRequest(port, AUTH_REQ_OK, NULL, 0);
 		}
 		else

--- a/src/postgres/src/backend/utils/init/miscinit.c
+++ b/src/postgres/src/backend/utils/init/miscinit.c
@@ -597,9 +597,7 @@ void
 InitializeSessionUserId(const char *rolename, Oid roleid)
 {
 	HeapTuple	roleTup;
-	HeapTuple	rolPrfTup;
 	Form_pg_authid rform;
-	Form_pg_yb_role_profile rpform;
 	char	   *rname;
 
 	/*
@@ -675,21 +673,6 @@ InitializeSessionUserId(const char *rolename, Oid roleid)
 					(errcode(ERRCODE_TOO_MANY_CONNECTIONS),
 					 errmsg("too many connections for role \"%s\"",
 							rname)));
-
-		if (*YBCGetGFlags()->ysql_enable_profile && YbLoginProfileCatalogsExist)
-		{
-			rolPrfTup = get_role_profile_tuple_by_role_oid(MyProc->roleId);
-			if (HeapTupleIsValid(rolPrfTup))
-			{
-				rpform = (Form_pg_yb_role_profile) GETSTRUCT(rolPrfTup);
-
-				if (rpform->rolprfstatus != ROLPRFSTATUS_OPEN)
-					ereport(FATAL,
-							(errcode(ERRCODE_INVALID_AUTHORIZATION_SPECIFICATION),
-							 errmsg("role \"%s\" is locked. Contact your database administrator.",
-									rname)));
-			}
-		}
 	}
 
 	/* Record username and superuser status as GUC settings too */


### PR DESCRIPTION
Jason's security finds:
> spamming logins gives more attempts than configured: https://phabricator.dev.yugabyte.com/D21043#inline-211617
> open login prompt lets you login after account is locked: https://phabricator.dev.yugabyte.com/D21043#inline-211622

(I can't reproduce either of those, so I'm not sure how much this change actually helps)

I thought maybe adding a second check to the session initalization would help, but that also occurs before we can access the actual data. Here's a POC of us moving the check to as late as possible in the set up. 

So now:
* auth.c checks the state (maybe stale) and increments the counter (to the maybe stale value + 1) 
* if auth.c allows the connection, postinit.c will double-check that the login should still be allowed, and only then reset the login attempts. This should help by ensuring that we don't incorrectly reset the value as often. 
