### PR TITLE
pg_shdepend TODOs 

### DIFF
--- a/src/postgres/src/backend/catalog/pg_shdepend.c
+++ b/src/postgres/src/backend/catalog/pg_shdepend.c
@@ -471,6 +471,28 @@ changeDependencyOnProfile(Oid classId, Oid objectId, Oid newProfileId)
 	heap_close(sdepRel, RowExclusiveLock);
 }
 
+
+
+/*
+ * dropDependencyOnProfile
+ *
+ * Delete all pg_shdepend entries corresponding to a user -> profile mapping.
+ */
+void
+dropDependencyOnProfile(Oid roleId)
+{
+	Relation	sdepRel;
+
+	sdepRel = heap_open(SharedDependRelationId, RowExclusiveLock);
+
+	shdepDropDependency(sdepRel, AuthIdRelationId, roleId, 0,
+						true,
+						YbProfileRelationId, InvalidOid,
+						SHARED_DEPENDENCY_PROFILE);
+
+	heap_close(sdepRel, RowExclusiveLock);
+}
+
 /*
  * getOidListDiff
  *		Helper for updateAclDependencies.

--- a/src/postgres/src/backend/catalog/pg_shdepend.c
+++ b/src/postgres/src/backend/catalog/pg_shdepend.c
@@ -451,7 +451,7 @@ recordDependencyOnProfile(Oid classId, Oid objectId, Oid profile)
  * have tablespaces.
  */
 void
-changeDependencyOnProfile(Oid classId, Oid objectId, Oid newProfileId)
+changeDependencyOnProfile(Oid roleId, Oid newProfileId)
 {
 	Relation	sdepRel;
 
@@ -459,12 +459,12 @@ changeDependencyOnProfile(Oid classId, Oid objectId, Oid newProfileId)
 
 	if (newProfileId != InvalidOid)
 		shdepChangeDep(sdepRel,
-					   classId, objectId, 0,
+					   AuthIdRelationId, roleId, 0,
 					   YbProfileRelationId, newProfileId,
 					   SHARED_DEPENDENCY_PROFILE);
 	else
 		shdepDropDependency(sdepRel,
-							classId, objectId, 0, true,
+							AuthIdRelationId, roleId, 0, true,
 							InvalidOid, InvalidOid,
 							SHARED_DEPENDENCY_INVALID);
 

--- a/src/postgres/src/backend/commands/user.c
+++ b/src/postgres/src/backend/commands/user.c
@@ -1146,7 +1146,8 @@ DropRole(DropRoleStmt *stmt)
 		/*
 		 * If the role is attached to a profile, auto-remove that association.
 		 */
-		YbRemoveRoleProfileForRoleIfExists(roleid);
+		if (*YBCGetGFlags()->ysql_enable_profile && YbLoginProfileCatalogsExist)
+			YbRemoveRoleProfileForRoleIfExists(roleid);
 
 		/*
 		 * Remove the role from the pg_authid table

--- a/src/postgres/src/backend/commands/yb_profile.c
+++ b/src/postgres/src/backend/commands/yb_profile.c
@@ -726,11 +726,5 @@ YbRemoveRoleProfileForRoleIfExists(Oid roleid)
 	heap_endscan(scandesc);
 	heap_close(rel, NoLock);
 
-	/*
-	 * TODO(profile): check that this deletes only role->profile pg_shdepend
-	 * record.  Assumption right now is that that is the only record that
-	 * exists where objid=role.  To be safe, it is probably best to make (or
-	 * find) a function to delete the specific role->profile dependency record.
-	 */
-	deleteSharedDependencyRecordsFor(AuthIdRelationId, roleid, 0);
+	dropDependencyOnProfile(roleid);
 }

--- a/src/postgres/src/backend/commands/yb_profile.c
+++ b/src/postgres/src/backend/commands/yb_profile.c
@@ -62,7 +62,7 @@ CheckProfileCatalogsExist()
  * Create a profile.
  */
 Oid
-YbCreateProfile(CreateProfileStmt *stmt)
+YbCreateProfile(YbCreateProfileStmt *stmt)
 {
 	Relation  rel;
 	Datum	  values[Natts_pg_yb_profile];
@@ -214,7 +214,7 @@ get_profile_name(Oid prfid)
  * DROP PROFILE
  */
 void
-YbDropProfile(DropProfileStmt *stmt)
+YbDropProfile(YbDropProfileStmt *stmt)
 {
 	char	   *prfname = stmt->prfname;
 	HeapScanDesc scandesc;

--- a/src/postgres/src/backend/commands/yb_profile.c
+++ b/src/postgres/src/backend/commands/yb_profile.c
@@ -316,11 +316,6 @@ YbDropProfile(YbDropProfileStmt *stmt)
 	heap_endscan(scandesc);
 
 	/*
-	 * Remove any comments or security labels on this profile.
-	 * TODO(profile): implement this if needed.
-	 */
-
-	/*
 	 * There is no owner to remove a shared dependency record for since
 	 * profiles are currently owned by any superuser or yb_db_admin.
 	 */

--- a/src/postgres/src/backend/commands/yb_profile.c
+++ b/src/postgres/src/backend/commands/yb_profile.c
@@ -559,7 +559,7 @@ YbCreateRoleProfile(Oid roleid, const char *rolename, const char *prfname)
 						new_record_repl, false);
 
 	/* Record dependency on profile */
-	changeDependencyOnProfile(AuthIdRelationId, roleid, prfid);
+	changeDependencyOnProfile(roleid, prfid);
 }
 
 /*

--- a/src/postgres/src/backend/nodes/copyfuncs.c
+++ b/src/postgres/src/backend/nodes/copyfuncs.c
@@ -4072,20 +4072,20 @@ _copyDiscardStmt(const DiscardStmt *from)
 	return newnode;
 }
 
-static CreateProfileStmt *
-_copyCreateProfileStmt(const CreateProfileStmt *from)
+static YbCreateProfileStmt *
+_copyCreateProfileStmt(const YbCreateProfileStmt *from)
 {
-	CreateProfileStmt *newnode = makeNode(CreateProfileStmt);
+	YbCreateProfileStmt *newnode = makeNode(YbCreateProfileStmt);
 
 	COPY_STRING_FIELD(prfname);
 	COPY_SCALAR_FIELD(prffailedloginattempts);
 	return newnode;
 }
 
-static DropProfileStmt *
-_copyDropProfileStmt(const DropProfileStmt *from)
+static YbDropProfileStmt *
+_copyDropProfileStmt(const YbDropProfileStmt *from)
 {
-	DropProfileStmt *newnode = makeNode(DropProfileStmt);
+	YbDropProfileStmt *newnode = makeNode(YbDropProfileStmt);
 
 	COPY_STRING_FIELD(prfname);
 	COPY_SCALAR_FIELD(missing_ok);
@@ -5531,10 +5531,10 @@ copyObjectImpl(const void *from)
 		case T_DiscardStmt:
 			retval = _copyDiscardStmt(from);
 			break;
-		case T_CreateProfileStmt:
+		case T_YbCreateProfileStmt:
 			retval = _copyCreateProfileStmt(from);
 			break;
-		case T_DropProfileStmt:
+		case T_YbDropProfileStmt:
 			retval = _copyDropProfileStmt(from);
 			break;
 		case T_CreateTableGroupStmt:

--- a/src/postgres/src/backend/nodes/equalfuncs.c
+++ b/src/postgres/src/backend/nodes/equalfuncs.c
@@ -1794,7 +1794,7 @@ _equalDiscardStmt(const DiscardStmt *a, const DiscardStmt *b)
 }
 
 static bool
-_equalCreateProfileStmt(const CreateProfileStmt *a, const CreateProfileStmt *b)
+_equalCreateProfileStmt(const YbCreateProfileStmt *a, const YbCreateProfileStmt *b)
 {
 	COMPARE_STRING_FIELD(prfname);
 	COMPARE_SCALAR_FIELD(prffailedloginattempts);
@@ -1802,7 +1802,7 @@ _equalCreateProfileStmt(const CreateProfileStmt *a, const CreateProfileStmt *b)
 }
 
 static bool
-_equalDropProfileStmt(const DropProfileStmt *a, const DropProfileStmt *b)
+_equalDropProfileStmt(const YbDropProfileStmt *a, const YbDropProfileStmt *b)
 {
 	COMPARE_STRING_FIELD(prfname);
 	COMPARE_SCALAR_FIELD(missing_ok);
@@ -3496,10 +3496,10 @@ equal(const void *a, const void *b)
 		case T_DiscardStmt:
 			retval = _equalDiscardStmt(a, b);
 			break;
-		case T_CreateProfileStmt:
+		case T_YbCreateProfileStmt:
 			retval = _equalCreateProfileStmt(a, b);
 			break;
-		case T_DropProfileStmt:
+		case T_YbDropProfileStmt:
 			retval = _equalDropProfileStmt(a, b);
 			break;
 		case T_CreateTableGroupStmt:

--- a/src/postgres/src/backend/parser/gram.y
+++ b/src/postgres/src/backend/parser/gram.y
@@ -312,7 +312,7 @@ static Node *makeRecursiveViewSelect(char *relname, List *aliases, Node *query);
 		CreateMatViewStmt RefreshMatViewStmt CreateAmStmt
 		CreatePublicationStmt AlterPublicationStmt
 		CreateSubscriptionStmt AlterSubscriptionStmt DropSubscriptionStmt
-		BackfillIndexStmt CreateProfileStmt DropProfileStmt
+		BackfillIndexStmt YbCreateProfileStmt YbDropProfileStmt
 
 %type <node>	select_no_parens select_with_parens select_clause
 				simple_select values_clause
@@ -922,7 +922,6 @@ stmt :
 			| CreateOpClassStmt
 			| CreateOpFamilyStmt
 			| CreatePolicyStmt
-			| CreateProfileStmt
 			| CreateRoleStmt
 			| CreateSchemaStmt
 			| CreateStatsStmt
@@ -941,7 +940,6 @@ stmt :
 			| DropOpFamilyStmt
 			| DropOwnedStmt
 			| DropPLangStmt
-			| DropProfileStmt
 			| DropRoleStmt
 			| DropStmt
 			| DropTableSpaceStmt
@@ -972,6 +970,8 @@ stmt :
 			| VariableSetStmt
 			| VariableShowStmt
 			| ViewStmt
+			| YbCreateProfileStmt
+			| YbDropProfileStmt
 
 			/* BETA features */
 			/* TODO(#10263): Fix individual beta flag feature bools */
@@ -4854,11 +4854,11 @@ DropTableSpaceStmt: DROP TABLESPACE name
  *
  *****************************************************************************/
 
-CreateProfileStmt: CREATE PROFILE name LIMIT FAILED_LOGIN_ATTEMPTS Iconst
+YbCreateProfileStmt: CREATE PROFILE name LIMIT FAILED_LOGIN_ATTEMPTS Iconst
 				{
 					if (!*YBCGetGFlags()->ysql_enable_profile)
 						parser_ybc_not_support(@1, "PROFILE");
-					CreateProfileStmt *n = makeNode(CreateProfileStmt);
+					YbCreateProfileStmt *n = makeNode(YbCreateProfileStmt);
 
 					n->prfname = $3;
 					if (strcmp(n->prfname, "default") == 0)
@@ -4880,11 +4880,11 @@ CreateProfileStmt: CREATE PROFILE name LIMIT FAILED_LOGIN_ATTEMPTS Iconst
  *
  *****************************************************************************/
 
-DropProfileStmt: DROP PROFILE name
+YbDropProfileStmt: DROP PROFILE name
 				{
 					if (!*YBCGetGFlags()->ysql_enable_profile)
 						parser_ybc_not_support(@1, "PROFILE");
-					DropProfileStmt *n = makeNode(DropProfileStmt);
+					YbDropProfileStmt *n = makeNode(YbDropProfileStmt);
 
 					n->prfname = $3;
 					if (strcmp(n->prfname, "default") == 0)
@@ -4901,7 +4901,7 @@ DropProfileStmt: DROP PROFILE name
 				{
 					if (!*YBCGetGFlags()->ysql_enable_profile)
 						parser_ybc_not_support(@1, "PROFILE");
-					DropProfileStmt *n = makeNode(DropProfileStmt);
+					YbDropProfileStmt *n = makeNode(YbDropProfileStmt);
 
 					n->prfname = $5;
 					if (strcmp(n->prfname, "default") == 0)

--- a/src/postgres/src/backend/tcop/utility.c
+++ b/src/postgres/src/backend/tcop/utility.c
@@ -239,8 +239,8 @@ check_xact_readonly(Node *parsetree)
 		case T_CreateSubscriptionStmt:
 		case T_AlterSubscriptionStmt:
 		case T_DropSubscriptionStmt:
-		case T_CreateProfileStmt:
-		case T_DropProfileStmt:
+		case T_YbCreateProfileStmt:
+		case T_YbDropProfileStmt:
 			PreventCommandIfReadOnly(CreateCommandTag(parsetree));
 			PreventCommandIfParallelMode(CreateCommandTag(parsetree));
 			break;
@@ -572,15 +572,15 @@ standard_ProcessUtility(PlannedStmt *pstmt,
 			break;
 
 		/* TODO(profile): move these YB cases to separate block. */
-		case T_CreateProfileStmt:
+		case T_YbCreateProfileStmt:
 			PreventInTransactionBlock(isTopLevel, "CREATE PROFILE");
-			YbCreateProfile((CreateProfileStmt *) parsetree);
+			YbCreateProfile((YbCreateProfileStmt *) parsetree);
 			break;
 
-		case T_DropProfileStmt:
+		case T_YbDropProfileStmt:
 			/* no event triggers for global objects */
 			PreventInTransactionBlock(isTopLevel, "DROP PROFILE");
-			YbDropProfile((DropProfileStmt *) parsetree);
+			YbDropProfile((YbDropProfileStmt *) parsetree);
 			break;
 
 		case T_TruncateStmt:
@@ -2904,11 +2904,11 @@ CreateCommandTag(Node *parsetree)
 			break;
 
 		/* TODO(profile): move these YB cases to separate block. */
-		case T_CreateProfileStmt:
+		case T_YbCreateProfileStmt:
 			tag = "CREATE PROFILE";
 			break;
 
-		case T_DropProfileStmt:
+		case T_YbDropProfileStmt:
 			tag = "DROP PROFILE";
 			break;
 

--- a/src/postgres/src/backend/tcop/utility.c
+++ b/src/postgres/src/backend/tcop/utility.c
@@ -571,18 +571,6 @@ standard_ProcessUtility(PlannedStmt *pstmt,
 			AlterTableSpaceOptions((AlterTableSpaceOptionsStmt *) parsetree);
 			break;
 
-		/* TODO(profile): move these YB cases to separate block. */
-		case T_YbCreateProfileStmt:
-			PreventInTransactionBlock(isTopLevel, "CREATE PROFILE");
-			YbCreateProfile((YbCreateProfileStmt *) parsetree);
-			break;
-
-		case T_YbDropProfileStmt:
-			/* no event triggers for global objects */
-			PreventInTransactionBlock(isTopLevel, "DROP PROFILE");
-			YbDropProfile((YbDropProfileStmt *) parsetree);
-			break;
-
 		case T_TruncateStmt:
 			ExecuteTruncate((TruncateStmt *) parsetree);
 			break;
@@ -972,6 +960,17 @@ standard_ProcessUtility(PlannedStmt *pstmt,
 					ExecSecLabelStmt(stmt);
 				break;
 			}
+
+		case T_YbCreateProfileStmt:
+			PreventInTransactionBlock(isTopLevel, "CREATE PROFILE");
+			YbCreateProfile((YbCreateProfileStmt *) parsetree);
+			break;
+
+		case T_YbDropProfileStmt:
+			/* no event triggers for global objects */
+			PreventInTransactionBlock(isTopLevel, "DROP PROFILE");
+			YbDropProfile((YbDropProfileStmt *) parsetree);
+			break;
 
 		default:
 			/* All other statement types have event trigger support */
@@ -2903,15 +2902,6 @@ CreateCommandTag(Node *parsetree)
 			tag = "ALTER COLLATION";
 			break;
 
-		/* TODO(profile): move these YB cases to separate block. */
-		case T_YbCreateProfileStmt:
-			tag = "CREATE PROFILE";
-			break;
-
-		case T_YbDropProfileStmt:
-			tag = "DROP PROFILE";
-			break;
-
 		case T_PrepareStmt:
 			tag = "PREPARE";
 			break;
@@ -3053,6 +3043,14 @@ CreateCommandTag(Node *parsetree)
 						break;
 				}
 			}
+			break;
+
+		case T_YbCreateProfileStmt:
+			tag = "CREATE PROFILE";
+			break;
+
+		case T_YbDropProfileStmt:
+			tag = "DROP PROFILE";
 			break;
 
 		default:

--- a/src/postgres/src/backend/utils/misc/pg_yb_utils.c
+++ b/src/postgres/src/backend/utils/misc/pg_yb_utils.c
@@ -1301,7 +1301,7 @@ bool IsTransactionalDdlStatement(PlannedStmt *pstmt,
 
 		case T_CreateDomainStmt:
 		case T_CreateEnumStmt:
-		case T_CreateProfileStmt:
+		case T_YbCreateProfileStmt:
 		case T_CreateTableGroupStmt:
 		case T_CreateTableSpaceStmt:
 		case T_DefineStmt: // CREATE OPERATOR/AGGREGATE/COLLATION/etc
@@ -1465,7 +1465,7 @@ bool IsTransactionalDdlStatement(PlannedStmt *pstmt,
 
 		// All T_Drop... tags from nodes.h:
 		case T_DropOwnedStmt:
-		case T_DropProfileStmt:
+		case T_YbDropProfileStmt:
 		case T_DropReplicationSlotCmd:
 		case T_DropRoleStmt:
 		case T_DropSubscriptionStmt:

--- a/src/postgres/src/include/catalog/dependency.h
+++ b/src/postgres/src/include/catalog/dependency.h
@@ -303,8 +303,7 @@ extern void changeDependencyOnTablespace(Oid classId, Oid objectId,
 
 extern void recordDependencyOnProfile(Oid classId, Oid objectId, Oid profile);
 
-extern void changeDependencyOnProfile(Oid classId, Oid objectId,
-									  Oid newProfileId);
+extern void changeDependencyOnProfile(Oid roleId, Oid newProfileId);
 
 extern void dropDependencyOnProfile(Oid roleId);
 

--- a/src/postgres/src/include/catalog/dependency.h
+++ b/src/postgres/src/include/catalog/dependency.h
@@ -306,6 +306,8 @@ extern void recordDependencyOnProfile(Oid classId, Oid objectId, Oid profile);
 extern void changeDependencyOnProfile(Oid classId, Oid objectId,
 									  Oid newProfileId);
 
+extern void dropDependencyOnProfile(Oid roleId);
+
 extern void updateAclDependencies(Oid classId, Oid objectId, int32 objectSubId,
 					  Oid ownerId,
 					  int noldmembers, Oid *oldmembers,

--- a/src/postgres/src/include/commands/yb_profile.h
+++ b/src/postgres/src/include/commands/yb_profile.h
@@ -27,8 +27,8 @@
 
 #include "nodes/parsenodes.h"
 
-extern Oid	YbCreateProfile(CreateProfileStmt* stmt);
-extern void YbDropProfile(DropProfileStmt* stmt);
+extern Oid	YbCreateProfile(YbCreateProfileStmt* stmt);
+extern void YbDropProfile(YbDropProfileStmt* stmt);
 
 extern Oid	get_profile_oid(const char* prfname, bool missing_ok);
 extern char* get_profile_name(Oid prfid);

--- a/src/postgres/src/include/nodes/nodes.h
+++ b/src/postgres/src/include/nodes/nodes.h
@@ -523,9 +523,8 @@ typedef enum NodeTag
 	T_YbSeqScanState,
 	T_YbBatchedNestLoop,
 	T_YbBatchedNestLoopState,
-	/* TODO(profile): rename these to have Yb prefix */
-	T_CreateProfileStmt,
-	T_DropProfileStmt,
+	T_YbCreateProfileStmt,
+	T_YbDropProfileStmt,
 
 } NodeTag;
 

--- a/src/postgres/src/include/nodes/parsenodes.h
+++ b/src/postgres/src/include/nodes/parsenodes.h
@@ -2191,19 +2191,19 @@ typedef struct OptSplit
  * ----------------------
  */
 
-typedef struct CreateProfileStmt
+typedef struct YbCreateProfileStmt
 {
 	NodeTag		type;
 	char	   *prfname;
 	Value	   *prffailedloginattempts;
-} CreateProfileStmt;
+} YbCreateProfileStmt;
 
-typedef struct DropProfileStmt
+typedef struct YbDropProfileStmt
 {
 	NodeTag		type;
 	char	   *prfname;
 	bool		missing_ok;		/* skip error if missing? */
-} DropProfileStmt;
+} YbDropProfileStmt;
 
 /* ----------------------
  *		Create/Drop Tablegroup Statements

--- a/src/postgres/src/tools/pgindent/typedefs.list
+++ b/src/postgres/src/tools/pgindent/typedefs.list
@@ -426,7 +426,6 @@ CreateOpClassStmt
 CreateOpFamilyStmt
 CreatePLangStmt
 CreatePolicyStmt
-CreateProfileStmt
 CreatePublicationStmt
 CreateRangeStmt
 CreateReplicationSlotCmd
@@ -2645,6 +2644,7 @@ XmlTableBuilderData
 YYLTYPE
 YYSTYPE
 YY_BUFFER_STATE
+YbCreateProfileStmt
 ZipfCache
 ZipfCell
 _SPI_connection


### PR DESCRIPTION
>  TODO(profile): disallow drop of the default profile once we introduce a default profile.

Leaving this in because it's a good thing to keep in mind for default profiles. 

> Check if there are snapshot schedules, disallow dropping in such cases. TODO(profile): determine if this limitation is really needed.

Being conservative by leaving this in. In the worst case the user needs to retry the DROP PROFILE.

Removed TODO for comments and security labels:
- comments are not supported on profiles right now. If they are added, the developer should handle that logic too. 
- security labels are not supported in YB right now

